### PR TITLE
add more customizations and fix typo

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -172,12 +172,19 @@ openAPI:
           values:
           - marker: PROJECT_NUMBER
             ref: '#/definitions/io.k8s.cli.setters.gcloud.project.projectNumber'
+    io.k8s.cli.setters.gcloud.api_endpoint_overrides.container:
+      x-k8s-cli:
+        setter:
+          name: gcloud.api_endpoint_overrides.container
+          value: "https://container.googleapis.com"
     io.k8s.cli.substitutions.gke-cluster-url:
       x-k8s-cli:
         substitution:
           name: gke-cluster-url
-          pattern: https://container.googleapis.com/v1/projects/PROJECT_ID/locations/LOCATION/clusters/CLUSTERNAME
+          pattern: CONTAINER_ENDPOINT/v1/projects/PROJECT_ID/locations/LOCATION/clusters/CLUSTERNAME
           values:
+          - marker: CONTAINER_ENDPOINT
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.api_endpoint_overrides.container'
           - marker: PROJECT_ID
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
           - marker: LOCATION
@@ -223,7 +230,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: galley-image
-          value: 'gcr.io/asm-testing/galley:release-1.5-asm-8'
+          value: 'gcr.io/asm-testing/galley:release-1.5-asm-10'
     io.k8s.cli.substitutions.galley-image:
       x-k8s-cli:
         substitution:
@@ -236,7 +243,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: istiod-image
-          value: 'gcr.io/asm-testing/pilot:release-1.5-asm-8'
+          value: 'gcr.io/asm-testing/pilot:release-1.5-asm-10'
     io.k8s.cli.substitutions.istiod-image:
       x-k8s-cli:
         substitution:
@@ -249,7 +256,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: proxy-image
-          value: 'gcr.io/asm-testing/proxyv2:release-1.5-asm-8'
+          value: 'gcr.io/asm-testing/proxyv2:release-1.5-asm-10'
     io.k8s.cli.substitutions.proxy-image:
       x-k8s-cli:
         substitution:
@@ -257,17 +264,24 @@ openAPI:
           pattern: IMAGE
           values:
           - marker: IMAGE
-            ref: '#/definitions/io.k8s.cli.setters.proxy-image'            
+            ref: '#/definitions/io.k8s.cli.setters.proxy-image'
     io.k8s.cli.setters.trace-id:
       x-k8s-cli:
         setter:
           name: trace-id
           value: '0'
+    io.k8s.cli.setters.enable-security-beta:
+      x-k8s-cli:
+        setter:
+          name: enable-security-beta
+          value: "false"
     io.k8s.cli.substitutions.sink-meta:
       x-k8s-cli:
         substitution:
           name: trace-id
-          pattern: "--sinkMeta=project_id=$(PROJECT_ID),sds_path=$(SDSPATH),trace=TRACEID"
+          pattern: "--sinkMeta=project_id=$(PROJECT_ID),sds_path=$(SDSPATH),trace=TRACEID,enable_security_beta=ENABLE_SECURITY_BETA"
           values:
           - marker: TRACEID
             ref: '#/definitions/io.k8s.cli.setters.trace-id'
+          - marker: ENABLE_SECURITY_BETA
+            ref: '#/definitions/io.k8s.cli.setters.enable-security-beta'

--- a/asm/trafficdirector/td-configmap-galley.yaml
+++ b/asm/trafficdirector/td-configmap-galley.yaml
@@ -18,4 +18,3 @@ data:
   GCP_METADATA: "[PROJECT_ID]|[PROJECT_NUMBER]|asm-free-trial|us-central1-c" # { "$ref": "#/definitions/io.k8s.cli.substitutions.gcp-metadata" }
   ISTIO_META_MESH_ID: "proj-[PROJECT_NUMBER]" # { "$ref": "#/definitions/io.k8s.cli.substitutions.mesh-id" }
   ISTIO_META_TRAFFICDIRECTOR_GCP_PROJECT_NUMBER: "[PROJECT_NUMBER]" # { "$ref": "#/definitions/io.k8s.cli.substitutions.gcp-project-number" }
-

--- a/asm/trafficdirector/td-galley.yaml
+++ b/asm/trafficdirector/td-galley.yaml
@@ -26,49 +26,49 @@ spec:
     spec:
       serviceAccountName: asm-galley-service-account
       containers:
-        - name: galley
-          image: gcr.io/asm-testing/galley:release-1.5-asm-10 # {"$ref":"#/definitions/io.k8s.cli.substitutions.galley-image"}
-          imagePullPolicy: "Always"
-          ports:
-          - containerPort: 9443
-          - containerPort: 15014
-          - containerPort: 15019
-          - containerPort: 9901
-          envFrom:
-            - configMapRef:
-                name: istio-galley-config-td
-                optional: true
-          command:
-          - /usr/local/bin/galley
-          - server
-          - --meshConfigFile=/etc/mesh-config/mesh
-          - --livenessProbeInterval=1s
-          - --livenessProbePath=/tmp/healthliveness
-          - --readinessProbePath=/tmp/healthready
-          - --readinessProbeInterval=1s
-          - --insecure=true
-          - --enable-validation=false
-          - --enable-reconcileWebhookConfiguration=false
-          - --enable-server=true
-          - --deployment-namespace=istio-system
-          - --validation-webhook-config-file
-          - /etc/config/validatingwebhookconfiguration.yaml
-          - --monitoringPort=15014
-          - --validation-port=9443
-          - --sinkAuthMode=$(SINKAUTHMODE)
-          - --sinkAddress=$(SINKADDRESS)
-          - --sinkMeta=project_id=$(PROJECT_ID),sds_path=$(SDSPATH),trace=0 # {"$ref":"#/definitions/io.k8s.cli.substitutions.sink-meta"}
-          - --excludedResourceKinds=Pod,Node,Endpoints
-          - --enableServiceDiscovery
-          volumeMounts:
-          - name: config
-            mountPath: /etc/config
-            readOnly: true
-          - name: mesh-config
-            mountPath: /etc/mesh-config
-            readOnly: true
-          - mountPath: /var/secrets/google
-            name: google-cloud-key
+      - name: galley
+        image: gcr.io/asm-testing/galley:release-1.5-asm-10 # {"$ref":"#/definitions/io.k8s.cli.substitutions.galley-image"}
+        imagePullPolicy: "Always"
+        ports:
+        - containerPort: 9443
+        - containerPort: 15014
+        - containerPort: 15019
+        - containerPort: 9901
+        envFrom:
+        - configMapRef:
+            name: istio-galley-config-td
+            optional: true
+        command:
+        - /usr/local/bin/galley
+        - server
+        - --meshConfigFile=/etc/mesh-config/mesh
+        - --livenessProbeInterval=1s
+        - --livenessProbePath=/tmp/healthliveness
+        - --readinessProbePath=/tmp/healthready
+        - --readinessProbeInterval=1s
+        - --insecure=true
+        - --enable-validation=false
+        - --enable-reconcileWebhookConfiguration=false
+        - --enable-server=true
+        - --deployment-namespace=istio-system
+        - --validation-webhook-config-file
+        - /etc/config/validatingwebhookconfiguration.yaml
+        - --monitoringPort=15014
+        - --validation-port=9443
+        - --sinkAuthMode=$(SINKAUTHMODE)
+        - --sinkAddress=$(SINKADDRESS)
+        - --sinkMeta=project_id=$(PROJECT_ID),sds_path=$(SDSPATH),trace=0,enable_security_beta=false # {"$ref":"#/definitions/io.k8s.cli.substitutions.sink-meta"}
+        - --excludedResourceKinds=Pod,Node,Endpoints
+        - --enableServiceDiscovery
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: mesh-config
+          mountPath: /etc/mesh-config
+          readOnly: true
+        - mountPath: /var/secrets/google
+          name: google-cloud-key
       volumes:
       - name: google-cloud-key
         secret:
@@ -80,4 +80,3 @@ spec:
       - name: mesh-config
         configMap:
           name: istio-mesh-td
----

--- a/asm/trafficdirector/td-istiod-asm.yaml
+++ b/asm/trafficdirector/td-istiod-asm.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -14,10 +13,10 @@ spec:
     kind: Deployment
     name: asm-td
   metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: 80
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 80
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -42,19 +41,19 @@ metadata:
     release: asm-td
 spec:
   ports:
-    - port: 443
-      name: https-inject
-      targetPort: 15017
-    - port: 15010
-      name: http2-xds # direct
-    - port: 15011
-      name: https-xds-spifeecert # mTLS
-    - port: 15012
-      name: https-xds-dnscert # mTLS
-    - port: 8080
-      name: http-legacy-discovery # direct
-    - port: 15014
-      name: http-monitoring
+  - port: 443
+    name: https-inject
+    targetPort: 15017
+  - port: 15010
+    name: http2-xds # direct
+  - port: 15011
+    name: https-xds-spifeecert # mTLS
+  - port: 15012
+    name: https-xds-dnscert # mTLS
+  - port: 8080
+    name: http-legacy-discovery # direct
+  - port: 15014
+    name: http-monitoring
   selector:
     app: asm-td
 ---
@@ -84,130 +83,127 @@ spec:
     spec:
       serviceAccountName: asm-td-service-account
       containers:
-        - name: discovery
-          image: gcr.io/asm-testing/pilot:release-1.5-asm-10 # {"$ref":"#/definitions/io.k8s.cli.substitutions.pilot-image"}
-          imagePullPolicy: Always
-          ports:
-            - containerPort: 8080
-            - containerPort: 15010
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 30
-            timeoutSeconds: 5
-          # Args used by pilot - istiod doesn't use args.
-          args:
-            - "discovery"
-            # TODO: make them default if istiod mode is enabled (ISTIOD_ADDR set)
-            - --secureGrpcAddr
-            - ""
-            - --namespace
-            - "istio-system"
-            # CRDs are created early, no need to hold RBAC permission
-            - --disable-install-crds=true
-          envFrom:
-          - configMapRef:
-              name: istio-galley-config-td
-              optional: false
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: CONFIG_NAMESPACE
-              value: istio-system
-            - name: ISTIOD_ADDR
-              value: asm-td.istio-system.svc:15012
-            - name: INJECTION_WEBHOOK_CONFIG_NAME
-              value: asm-td
-            - name: PILOT_EXTERNAL_GALLEY
-              value: "false"
-            - name: PROXY_IMAGE
-              value: gcr.io/asm-testing/proxyv2:release-1.5-asm-10 # { "$ref": "#/definitions/io.k8s.cli.subsstitutions.proxy-image" }
-          resources:
-            requests:
-              cpu: 101m
-              memory: 64Mi
-          volumeMounts:
-            # For backward compat, if secrets already exists. Currently not used/implemented
-            # Instead shifting traffic to istiod
-            - name: istio-certs
-              mountPath: /var/run/secrets/istio
-              readOnly: true
-            # Technically not needed on this pod - but it helps debugging/testing SDS
-            # Should be removed after everything works.
-            - name: istio-token
-              mountPath: /var/run/secrets/tokens
-              readOnly: true
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: cacerts
-              mountPath: /etc/cacerts
-              readOnly: true
-            - name: mesh
-              mountPath: /etc/istio/config
-              readOnly: true
-            - name: inject
-              mountPath: /var/lib/istio/inject
-              readOnly: true
-            - name: asm-td
-              mountPath: /var/lib/istio/local
-              readOnly: true
-            - mountPath: /var/secrets/google
-              name: google-cloud-key
-            - mountPath: /var/lib/istio/galley
-              name: asm-td
-
+      - name: discovery
+        image: gcr.io/asm-testing/pilot:release-1.5-asm-10 # {"$ref":"#/definitions/io.k8s.cli.substitutions.pilot-image"}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        - containerPort: 15010
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          timeoutSeconds: 5
+        # Args used by pilot - istiod doesn't use args.
+        args:
+        - "discovery"
+        # TODO: make them default if istiod mode is enabled (ISTIOD_ADDR set)
+        - --secureGrpcAddr
+        - ""
+        - --namespace
+        - "istio-system"
+        # CRDs are created early, no need to hold RBAC permission
+        - --disable-install-crds=true
+        envFrom:
+        - configMapRef:
+            name: istio-galley-config-td
+            optional: false
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CONFIG_NAMESPACE
+          value: istio-system
+        - name: ISTIOD_ADDR
+          value: asm-td.istio-system.svc:15012
+        - name: INJECTION_WEBHOOK_CONFIG_NAME
+          value: asm-td
+        - name: PILOT_EXTERNAL_GALLEY
+          value: "false"
+        - name: PROXY_IMAGE
+          value: gcr.io/asm-testing/proxyv2:release-1.5-asm-10 # { "$ref": "#/definitions/io.k8s.cli.substitutions.proxy-image" }
+        resources:
+          requests:
+            cpu: 101m
+            memory: 64Mi
+        volumeMounts:
+        - # Instead shifting traffic to istiod
+          name: istio-certs # For backward compat, if secrets already exists. Currently not used/implemented
+          mountPath: /var/run/secrets/istio
+          readOnly: true
+        - # Should be removed after everything works.
+          name: istio-token # Technically not needed on this pod - but it helps debugging/testing SDS
+          mountPath: /var/run/secrets/tokens
+          readOnly: true
+        - name: local-certs
+          mountPath: /var/run/secrets/istio-dns
+        - name: cacerts
+          mountPath: /etc/cacerts
+          readOnly: true
+        - name: mesh
+          mountPath: /etc/istio/config
+          readOnly: true
+        - name: inject
+          mountPath: /var/lib/istio/inject
+          readOnly: true
+        - name: asm-td
+          mountPath: /var/lib/istio/local
+          readOnly: true
+        - mountPath: /var/secrets/google
+          name: google-cloud-key
+        - mountPath: /var/lib/istio/galley
+          name: asm-td
       securityContext:
         # Temp, for debugging (need to install tools, etc)
         runAsUser: 0
         runAsGroup: 1337
       volumes:
-        - emptyDir:
-            medium: Memory
-          name: local-certs
-        - name: istio-token
-          projected:
-            sources:
-              - serviceAccountToken:
-                  audience: "[PROJECT_ID].svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
-                  expirationSeconds: 43200
-                  path: istio-token
-        - name: istio-certs
-          secret:
-            secretName: istio.istio-pilot-service-account
-            optional: true
-        - name: asm-td
-          configMap:
-            name: istio-galley-config-td
-            optional: false
-        - name: google-cloud-key
-          secret:
-            secretName: google-cloud-key
-            optional: true
-        # Optional: user-generated root
-        - name: cacerts
-          secret:
-            secretName: cacerts
-            optional: true
-        # Optional - image should have
-        - name: inject
-          configMap:
-            name: istio-sidecar-injector-td
-            optional: true
-        - name: mesh
-          configMap:
-            name: istio-mesh-td
-            optional: false
-        - name: galley
-          configMap:
-            name: istio-galley-config-td
-            optional: false
+      - emptyDir:
+          medium: Memory
+        name: local-certs
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: "[PROJECT_ID].svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
+              expirationSeconds: 43200
+              path: istio-token
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-pilot-service-account
+          optional: true
+      - name: asm-td
+        configMap:
+          name: istio-galley-config-td
+          optional: false
+      - name: google-cloud-key
+        secret:
+          secretName: google-cloud-key
+          optional: true
+      # Optional: user-generated root
+      - name: cacerts
+        secret:
+          secretName: cacerts
+          optional: true
+      # Optional - image should have
+      - name: inject
+        configMap:
+          name: istio-sidecar-injector-td
+          optional: true
+      - name: mesh
+        configMap:
+          name: istio-mesh-td
+          optional: false
+      - name: galley
+        configMap:
+          name: istio-galley-config-td
+          optional: false


### PR DESCRIPTION
This PR:
- Fix a typo in `definitions/io.k8s.cli.substitutions.proxy-image`
- Make the GCP container endpoint configurable in `gkeClusterUrl`
- Add a new parameter `enable_security_beta` to `--sinkMeta`
- Change galley and pilot image to `release-1.5-asm-10` to be consistent with proxy